### PR TITLE
import dplyr::n()

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -7,7 +7,7 @@ export(alg2param, Pretreatment, RobustScores, SplitHalf, TestRetest, Tgraph,
        TestRetest.D2SWND, TestRetest.D5SWND, TestRetest.D6SWND,
        IATdescriptives)
 importFrom("dplyr","%>%","group_by", "summarize", "left_join", "mutate",
-           "inner_join", "select", "bind_rows", "arrange", "filter")
+           "inner_join", "select", "bind_rows", "arrange", "filter", "n")
 importFrom("stringr", "str_c", "str_replace", "str_split", "str_trim",
            "str_sub")
 importFrom("reshape2","dcast", "melt")


### PR DESCRIPTION
Starting from dplyr 1.0.0 released soon, `n()` is no longer magic, so you need to prefix or import. 

dplyr reverse dependency checks shows: 

```
[master*] 129.1 MiB ❯ revdepcheck::revdep_details(, "IATscores")
══ Reverse dependency check ═════════════════════════════════ IATscores 0.2.4 ══

Status: BROKEN

── Newly failing

✖ checking examples ... ERROR

── Before ──────────────────────────────────────────────────────────────────────
0 errors ✔ | 0 warnings ✔ | 0 notes ✔

── After ───────────────────────────────────────────────────────────────────────

❯ checking examples ... ERROR
  Running examples in ‘IATscores-Ex.R’ failed
  The error most likely occurred in:

  > ### Name: IATdescriptives
  > ### Title: Summary statistics of reaction time and error
  > ### Aliases: IATdescriptives
  >
  > ### ** Examples
  >
  > #### generate random IAT data ####
  > set.seed(1234)
  > rawIATdata <- data.frame(
  +   # ID of each participant (N = 10)
  +   ID = rep(1:10, each = 180),
  +   # seven-block structure, as in Greenwald, Nosek & Banaji (2003)
  +   # block 1 = target discrimination (e.g., Bush vs. Gore items)
  +   # block 2 = attribute discrimination (e.g., Pleasant words vs. unpleasant)
  +   # block 3 = combined practice (e.g., Bush + pleasant vs. Gore + unpleasant)
  +   # block 4 = combined critical  (e.g., Bush + pleasant vs. Gore + unpleasant)
  +   # block 5 = reversed target discrimination (e.g., Gore vs. Bush)
  +   # block 6 = reversed combined practice (e.g., Gore + pleasant vs. Bush + unpleasant)
  +   # block 7 = reversed combined critical (e.g., Gore + pleasant vs. Bush + unpleasant)
  +   block = rep(c(rep(1:3, each = 20),
  +                 rep(4, 40),
  +                 rep(5:6, each = 20),
  +                 rep(7, 40)), 10),
  +   # expected proportion of errors = 10 percent
  +   correct = sample(c(0, 1), size = 1800, replace = TRUE, prob = c(.2, .8)),
  +   # reaction times are generated from a mix of two chi2 distributions,
  +   # one centered on 550ms and one on 100ms to simulate fast latencies
  +   latency = round(sample(c(rchisq(1500, df = 1, ncp = 550),
  +                            rchisq(300, df = 1, ncp = 100)), 1800)))
  >
  > # add some IAT effect by making trials longer in block 6 and 7
  > rawIATdata[rawIATdata$block >= 6, "latency"] <-
  +   rawIATdata[rawIATdata$block >= 6, "latency"] + 100
  >
  > # add some more effect for subjects 1 to 5
  > rawIATdata[rawIATdata$block >= 6 &
  +              rawIATdata$ID <= 5, "latency"] <-
  +   rawIATdata[rawIATdata$block >= 6 &
  +              rawIATdata$ID <= 5, "latency"] + 100
  >
  > #### pretreat IAT data using function Pretreatment ####
  > IATdata <- Pretreatment(rawIATdata,
  +                              label_subject = "ID",
  +                           label_latency = "latency",
  +                           label_accuracy = "correct",
  +                           label_block = "block",
  +                           block_pair1 = c(3, 4),
  +                           block_pair2 = c(6, 7),
  +                           label_praccrit = "block",
  +                           block_prac = c(3, 6),
  +                           block_crit = c(4, 7))
  > IATdescriptives(IATdata)
  Error: `summarise()` argument `N_trials` errored.
  ℹ `N_trials` is `n()`.
  ℹ The error occured in group 1: subject = 1.
  ✖ could not find function "n"
  Backtrace:
       █
    1. └─IATscores::IATdescriptives(IATdata)
    2.   └─`%>%`(...)
    3.     ├─base::withVisible(eval(quote(`_fseq`(`_lhs`)), env, env))
    4.     └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
    5.       └─base::eval(quote(`_fseq`(`_lhs`)), env, env)
    6.         └─IATscores:::`_fseq`(`_lhs`)
    7.           └─magrittr::freduce(value, `_function_list`)
    8.             ├─base::withVisible(function_list[[k]](value))
    9.             └─function_list[[k]](value)
   10.               ├─dplyr::summarize(...)
   11.               ├─dplyr:::summarise.grouped_df(...)
   12.               ├─base::NextMethod()
   13.               └─dplyr:::summarise.data.frame(...)
   14.                 └─dplyr:::summarise_cols(.data, ...)
   15.                   └─base::tryCatch(...)
   16.
  Execution halted

1 error ✖ | 0 warnings ✔ | 0 notes ✔
```